### PR TITLE
Don't use uninitialized $!socket during debug

### DIFF
--- a/lib/SCGI.pm6
+++ b/lib/SCGI.pm6
@@ -46,11 +46,18 @@ method accept ()
 method handle (&closure) 
 {
   if ($.debug) {
-    $*ERR.say: "socket family is "~$.socket.family;
-    $*ERR.say: "socket proto is "~$.socket.proto;
-    $*ERR.say: "socket type is "~$.socket.type;
+    if $!socket
+    {
+      $*ERR.say: "socket family is "~$.socket.family;
+      $*ERR.say: "socket proto is "~$.socket.proto;
+      $*ERR.say: "socket type is "~$.socket.type;
+    }
+    else
+    {
+      $*ERR.say: "No socket yet";
+    }
   }
-  $*ERR.say: "[{time}] SCGI is ready and waiting.";
+  $*ERR.say: "[{time}] SCGI is ready and waiting ($!addr:$!port)";
   while (my $connection = self.accept) 
   {
     if ($.debug) { $*ERR.say: "Doing the loop"; }


### PR DESCRIPTION
$.socket may not be initialized when handle() is called (letting handle's self.accept() call initialize it). Don't use it in debug statements in that case.

Also, report the $.addr and $.port in handle()'s startup message.
