### PR TITLE
Describe how to rehome app URI in nginx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,13 @@ Make sure you compiled nginx with the SCGI plugin (it is included by default.)
 Then, in one of your server blocks, add a location mount:
 
 ```nginx
-  location /scgi {
+  location /scgi/ {
     scgi_pass 127.0.0.1:8118;
     include scgi_params;
+    # Optionally rewrite document URI path
+    rewrite ^/scgi/(.*) /$1 break;
+    # Some applications may need rewritten URI in PATH_INFO
+    scgi_param PATH_INFO $uri;
   }
 ```
 


### PR DESCRIPTION
An application may use the DOCUMENT_URI or PATH_INFO param for routing requests internally. Routes typically assume a path is relative to the application, so in our example: "GET /scgi/foo/bar" would be matched with a get('/foo/bar') route selector. The nginx config should strip the location prefix, so the application doesn't have to hard-code its URI-space mount point.

Also, use "location /scgi/" instead of "location /scgi", to enable the rewrite rule to always succeed. If client requests "/scgi", nginx automatically sends a 301 redirect to "/scgi/".
