### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
   "perl"        : "6.*",
   "name"        : "SCGI",
+  "license"     : "Artistic-2.0",
   "version"     : "2.4",
   "description" : "A SCGI library for Perl 6",
   "depends"     : [ "HTTP::Status", "Netstring", "PSGI" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license